### PR TITLE
refactor/template-registry

### DIFF
--- a/.claude/docs/git-workflow.md
+++ b/.claude/docs/git-workflow.md
@@ -72,19 +72,68 @@ label/domain
 
 ### 1. Issue 생성
 
-기능 단위로 Issue를 생성합니다. Issue 본문은 한글로 작성합니다.
+작업 유형에 맞는 Issue 템플릿을 선택하여 생성합니다. Issue 본문은 한글로 작성합니다.
 
+**Task** (일반 작업):
 ```bash
-gh issue create --title "브랜치명" --body "$(cat <<'EOF'
-## 제목
-제목제목제목
+gh issue create --title "[TASK] 설명" --label "Fix" --body "$(cat <<'EOF'
+## 작업 개요
 
-## 작업한 내용
+## TO DO
 - [ ] 작업1
 - [ ] 작업2
 
 ## 전달할 추가 이슈
-- 이슈1 (없으면 "없음")
+- 이슈1
+- 이슈2
+EOF
+)"
+```
+
+**Feature Request** (새 기능):
+```bash
+gh issue create --title "[FEATURE] 설명" --label "Feature" --body "$(cat <<'EOF'
+## 기능 개요
+
+## 세부 기능
+
+## 기능 플로우
+
+## TO DO
+- [ ]
+EOF
+)"
+```
+
+**Bug Report** (버그):
+```bash
+gh issue create --title "[BUG] 설명" --label "Bug" --body "$(cat <<'EOF'
+## 버그 개요
+
+## 버그 내용
+-
+-
+
+## 재현 경로
+
+## TO DO
+- [ ]
+- [ ]
+EOF
+)"
+```
+
+**Security Report** (보안):
+```bash
+gh issue create --title "[SECURITY] 설명" --label "Bug,Hotfix" --body "$(cat <<'EOF'
+## 보안 이슈 개요
+
+## 관련 CVE
+-
+-
+
+## TO DO
+- [ ]
 EOF
 )"
 ```
@@ -136,26 +185,61 @@ EOF
 )"
 ```
 
-## Issue / PR 템플릿 (필수)
+## Issue 템플릿 (필수)
 
-> **⚠️ Issue와 PR 본문은 반드시 아래 템플릿을 사용해야 합니다. 자의적으로 섹션을 변경하거나 추가하지 마세요.**
+> **⚠️ Issue 본문은 반드시 아래 4가지 템플릿 중 적절한 것을 선택하여 사용합니다. 자의적으로 섹션을 변경하거나 추가하지 마세요.**
 
+**Task** — `[TASK]` / labels: `Fix`:
 ```
-## 제목
-제목제목제목
+## 작업 개요
 
-## 작업한 내용
+## TO DO
 - [ ] 작업1
 - [ ] 작업2
 
 ## 전달할 추가 이슈
-- 이슈1 (없으면 "없음")
+- 이슈1
+- 이슈2
 ```
 
-- **Issue**: `작업한 내용`은 `- [ ]` (미완료 체크박스)
-- **PR**: `작업한 내용`은 `- [x]` (완료 체크박스)
-- **제목 섹션**: Issue는 작업 설명, PR은 브랜치명
-- `## 개요`, `## 변경사항`, `## 관련 파일` 등 **다른 형식 사용 금지**
+**Feature Request** — `[FEATURE]` / labels: `Feature`:
+```
+## 기능 개요
+
+## 세부 기능
+
+## 기능 플로우
+
+## TO DO
+- [ ]
+```
+
+**Bug Report** — `[BUG]` / labels: `Bug`:
+```
+## 버그 개요
+
+## 버그 내용
+-
+-
+
+## 재현 경로
+
+## TO DO
+- [ ]
+- [ ]
+```
+
+**Security Report** — `[SECURITY]` / labels: `Bug, Hotfix`:
+```
+## 보안 이슈 개요
+
+## 관련 CVE
+-
+-
+
+## TO DO
+- [ ]
+```
 
 ## Important Notes
 

--- a/bin/create-bigtablet-frontend.js
+++ b/bin/create-bigtablet-frontend.js
@@ -1,113 +1,188 @@
 #!/usr/bin/env node
 
+// src/index.ts
+import { log, outro } from "@clack/prompts";
+
+// src/steps/install.ts
+import { execSync } from "child_process";
+import { spinner } from "@clack/prompts";
+var installDependencies = (targetDirectory, packageManagerInfo) => {
+  const installationSpinner = spinner();
+  installationSpinner.start(`${packageManagerInfo.name}\uC73C\uB85C \uC758\uC874\uC131\uC744 \uC124\uCE58\uD558\uB294 \uC911...`);
+  try {
+    execSync(packageManagerInfo.installCommand, {
+      cwd: targetDirectory,
+      stdio: "pipe"
+    });
+    installationSpinner.stop("\uC758\uC874\uC131 \uC124\uCE58 \uC644\uB8CC");
+  } catch (error) {
+    installationSpinner.stop("\uC758\uC874\uC131 \uC124\uCE58 \uC2E4\uD328");
+    throw error;
+  }
+};
+
+// src/steps/prompt.ts
+import { cancel, intro, isCancel, select, text } from "@clack/prompts";
+import fs2 from "fs";
+import path2 from "path";
+
+// src/registry.ts
 import fs from "fs";
 import path from "path";
-import { execSync } from "child_process";
 import { fileURLToPath } from "url";
+var TEMPLATES = [
+  {
+    name: "design-system",
+    label: "@bigtablet/design-system",
+    hint: "Bigtablet \uC0AC\uB0B4 \uCEF4\uD3EC\uB10C\uD2B8 (SCSS)"
+  },
+  {
+    name: "shadcn",
+    label: "shadcn/ui",
+    hint: "Tailwind CSS v4 + Radix UI"
+  }
+];
+var cachedTemplates = null;
+function getTemplates() {
+  if (cachedTemplates !== null) return cachedTemplates;
+  cachedTemplates = TEMPLATES.filter((t) => {
+    if (typeof t.isEnabled === "function") return t.isEnabled();
+    return true;
+  });
+  return cachedTemplates;
+}
+function findTemplate(name) {
+  return getTemplates().find((t) => t.name === name);
+}
+function getTemplateDir(templateName) {
+  const currentFilename = fileURLToPath(import.meta.url);
+  const cliRoot = path.resolve(path.dirname(currentFilename), "..");
+  return path.resolve(cliRoot, "templates", templateName);
+}
+function templateExists(templateName) {
+  return fs.existsSync(getTemplateDir(templateName));
+}
 
-const projectName = process.argv[2];
+// src/steps/prompt.ts
+var runPrompts = async (initialProjectName) => {
+  intro("@bigtablet/create-frontend");
+  const projectName = await text({
+    message: "\uD504\uB85C\uC81D\uD2B8 \uC774\uB984\uC744 \uC785\uB825\uD558\uC138\uC694:",
+    placeholder: "my-app",
+    initialValue: initialProjectName,
+    validate: (value = "") => {
+      if (!value.trim()) return "\uD504\uB85C\uC81D\uD2B8 \uC774\uB984\uC774 \uD544\uC694\uD569\uB2C8\uB2E4.";
+      if (fs2.existsSync(path2.resolve(process.cwd(), value))) {
+        return `"${value}" \uB514\uB809\uD1A0\uB9AC\uAC00 \uC774\uBBF8 \uC874\uC7AC\uD569\uB2C8\uB2E4.`;
+      }
+    }
+  });
+  if (isCancel(projectName)) {
+    cancel("\uC791\uC5C5\uC774 \uCDE8\uC18C\uB410\uC2B5\uB2C8\uB2E4.");
+    process.exit(0);
+  }
+  const templates = getTemplates();
+  const templateName = await select({
+    message: "\uD15C\uD50C\uB9BF\uC744 \uC120\uD0DD\uD558\uC138\uC694:",
+    options: templates.map((t) => ({
+      value: t.name,
+      label: t.label,
+      hint: t.hint
+    }))
+  });
+  if (isCancel(templateName)) {
+    cancel("\uC791\uC5C5\uC774 \uCDE8\uC18C\uB410\uC2B5\uB2C8\uB2E4.");
+    process.exit(0);
+  }
+  return {
+    projectName,
+    templateName
+  };
+};
 
-if (!projectName) {
-    console.error("Project name is required.");
+// src/steps/scaffold.ts
+import fs3 from "fs";
+import path3 from "path";
+var GITIGNORE_CONTENT = [
+  "node_modules/",
+  ".next/",
+  "out/",
+  "dist/",
+  "build/",
+  "",
+  ".env",
+  ".env.local",
+  ".env.*.local",
+  "",
+  "*.log",
+  ".DS_Store",
+  ".vercel/",
+  ""
+].join("\n");
+var scaffoldProject = async (projectName, templateName, packageManagerInfo) => {
+  if (!templateExists(templateName)) {
+    throw new Error(`\uD15C\uD50C\uB9BF "${templateName}"\uC744(\uB97C) \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.`);
+  }
+  const targetDirectory = path3.resolve(process.cwd(), projectName);
+  try {
+    const templateDirectory = getTemplateDir(templateName);
+    fs3.cpSync(templateDirectory, targetDirectory, { recursive: true });
+    fs3.writeFileSync(path3.join(targetDirectory, ".gitignore"), GITIGNORE_CONTENT);
+    fs3.writeFileSync(path3.join(targetDirectory, ".env.example"), "NEXT_PUBLIC_SERVER_URL=\n");
+    const packageJsonPath = path3.join(targetDirectory, "package.json");
+    const packageJsonContent = fs3.readFileSync(packageJsonPath, "utf8");
+    fs3.writeFileSync(packageJsonPath, packageJsonContent.replace("__PROJECT_NAME__", projectName));
+    if (packageManagerInfo.version) {
+      const packageJson = JSON.parse(fs3.readFileSync(packageJsonPath, "utf8"));
+      packageJson.packageManager = `${packageManagerInfo.name}@${packageManagerInfo.version}`;
+      fs3.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, "	") + "\n");
+    }
+    const template = findTemplate(templateName);
+    if (template?.afterScaffold) {
+      await template.afterScaffold(targetDirectory);
+    }
+    return targetDirectory;
+  } catch (error) {
+    fs3.rmSync(targetDirectory, { recursive: true, force: true });
+    throw error;
+  }
+};
+
+// src/utils/package-manager.ts
+var detectPackageManager = () => {
+  const userAgent = process.env.npm_config_user_agent ?? "";
+  const name = userAgent.includes("pnpm") ? "pnpm" : userAgent.includes("yarn") ? "yarn" : "npm";
+  const versionMatch = userAgent.match(new RegExp(`${name}/(\\S+)`));
+  const version = versionMatch?.[1]?.split(" ")[0] ?? "";
+  const installCommand = name === "yarn" ? "yarn install" : `${name} install`;
+  return { name, version, installCommand };
+};
+var getDevCommand = (packageManagerName) => packageManagerName === "npm" ? "npm run dev" : `${packageManagerName} dev`;
+
+// src/index.ts
+var main = async () => {
+  const [nodeMajorVersion] = process.versions.node.split(".").map(Number);
+  if (nodeMajorVersion < 24) {
+    console.error("Node.js 24 \uC774\uC0C1\uC774 \uD544\uC694\uD569\uB2C8\uB2E4.");
     process.exit(1);
-}
-
-const [nodeMajor] = process.versions.node.split(".").map(Number);
-
-if (nodeMajor < 24) {
-    console.error("Node.js 24 or higher is required.");
-    process.exit(1);
-}
-
-const targetDir = path.resolve(process.cwd(), projectName);
-
-if (fs.existsSync(targetDir)) {
-    console.error(`Directory "${projectName}" already exists.`);
-    process.exit(1);
-}
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const templateDir = path.resolve(__dirname, "../template");
-
-fs.cpSync(templateDir, targetDir, { recursive: true });
-
-fs.writeFileSync(
-    path.join(targetDir, ".gitignore"),
-    [
-        "node_modules/",
-        ".next/",
-        "out/",
-        "dist/",
-        "build/",
-        "",
-        ".env",
-        ".env.local",
-        ".env.*.local",
-        "",
-        "*.log",
-        ".DS_Store",
-        ".vercel/",
-        "",
-    ].join("\n")
-);
-
-fs.writeFileSync(
-    path.join(targetDir, ".env.example"),
-    "NEXT_PUBLIC_SERVER_URL=\n"
-);
-
-const pkgPath = path.join(targetDir, "package.json");
-const pkg = fs.readFileSync(pkgPath, "utf8");
-
-fs.writeFileSync(
-    pkgPath,
-    pkg.replace("__PROJECT_NAME__", projectName)
-);
-
-const userAgent = process.env.npm_config_user_agent || "";
-
-const packageManager = userAgent.includes("pnpm")
-    ? "pnpm"
-    : userAgent.includes("yarn")
-        ? "yarn"
-        : "npm";
-
-const pmVersion = userAgent.match(new RegExp(`${packageManager}/(\\S+)`))?.[1]?.split(" ")[0] || "";
-
-if (pmVersion) {
-    const pkgJson = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-    pkgJson.packageManager = `${packageManager}@${pmVersion}`;
-    fs.writeFileSync(pkgPath, JSON.stringify(pkgJson, null, "\t") + "\n");
-}
-
-const installCommand =
-    packageManager === "yarn"
-        ? "yarn install"
-        : `${packageManager} install`;
-
-console.log(`Installing dependencies using ${packageManager}...`);
-
-try {
-    execSync(installCommand, {
-        cwd: targetDir,
-        stdio: "inherit",
-    });
-} catch {
-    console.error("Failed to install dependencies.");
-    process.exit(1);
-}
-
-console.log("");
-console.log("Project created successfully.");
-console.log("");
-console.log("Next steps:");
-console.log(`  cd ${projectName}`);
-console.log(
-    `  ${
-        packageManager === "npm"
-            ? "npm run dev"
-            : `${packageManager} dev`
-    }`
-);
+  }
+  const initialProjectName = process.argv[2];
+  const projectConfig = await runPrompts(initialProjectName);
+  const packageManagerInfo = detectPackageManager();
+  const targetDirectory = await scaffoldProject(
+    projectConfig.projectName,
+    projectConfig.templateName,
+    packageManagerInfo
+  );
+  installDependencies(targetDirectory, packageManagerInfo);
+  log.success("\uD504\uB85C\uC81D\uD2B8\uAC00 \uC0DD\uC131\uB410\uC2B5\uB2C8\uB2E4.");
+  outro(
+    `\uB2E4\uC74C \uB2E8\uACC4:
+  cd ${projectConfig.projectName}
+  ${getDevCommand(packageManagerInfo.name)}`
+  );
+};
+main().catch((error) => {
+  console.error("\uC624\uB958\uAC00 \uBC1C\uC0DD\uD588\uC2B5\uB2C8\uB2E4:", error);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,9 +35,9 @@ const main = async (): Promise<void> => {
 
 	const packageManagerInfo = detectPackageManager();
 
-	const targetDirectory = scaffoldProject(
+	const targetDirectory = await scaffoldProject(
 		projectConfig.projectName,
-		projectConfig.designSystem,
+		projectConfig.templateName,
 		packageManagerInfo,
 	);
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * @description
+ * 템플릿 플러그인 정의입니다.
+ *
+ * 새 템플릿을 추가하려면:
+ * 1. `templates/{name}/` 폴더에 Next.js 프로젝트를 넣는다
+ * 2. 이 파일의 `TEMPLATES` 배열에 항목을 추가한다
+ * 3. 끝 (prompt.ts, scaffold.ts 수정 불필요)
+ */
+export type TemplateDefinition = {
+	/** 내부 식별자. templates/ 하위 폴더명과 일치해야 합니다. */
+	name: string;
+	/** CLI 선택 목록에 표시되는 이름 */
+	label: string;
+	/** CLI 선택 목록에 표시되는 힌트 */
+	hint: string;
+	/**
+	 * 조건부 활성화 함수. 반환값이 false면 CLI 선택지에 표시되지 않습니다.
+	 * 미설정 시 항상 표시됩니다.
+	 *
+	 * @example
+	 * // 환경변수가 설정된 경우에만 노출 (실험적 템플릿 등)
+	 * isEnabled: () => process.env.BIGTABLET_EXPERIMENTAL === "true"
+	 */
+	isEnabled?: () => boolean;
+	/**
+	 * 스캐폴딩 완료 후 실행되는 후처리 함수.
+	 * 템플릿별 커스텀 파일 생성, 설정 패치 등에 사용합니다.
+	 *
+	 * @param targetDir - 생성된 프로젝트의 절대 경로
+	 */
+	afterScaffold?: (targetDir: string) => Promise<void> | void;
+};
+
+// ─── 템플릿 목록 ────────────────────────────────────────────────────────────────
+// 새 템플릿 추가: 아래 배열에 항목만 추가하면 됩니다.
+
+const TEMPLATES: TemplateDefinition[] = [
+	{
+		name: "design-system",
+		label: "@bigtablet/design-system",
+		hint: "Bigtablet 사내 컴포넌트 (SCSS)",
+	},
+	{
+		name: "shadcn",
+		label: "shadcn/ui",
+		hint: "Tailwind CSS v4 + Radix UI",
+	},
+];
+
+// ─── 레지스트리 API ──────────────────────────────────────────────────────────────
+
+let cachedTemplates: TemplateDefinition[] | null = null;
+
+/**
+ * 활성화된 템플릿 목록을 반환합니다.
+ * `isEnabled()`가 false를 반환하는 템플릿은 제외됩니다.
+ * 결과는 프로세스 내에서 메모이즈됩니다.
+ */
+export function getTemplates(): TemplateDefinition[] {
+	if (cachedTemplates !== null) return cachedTemplates;
+
+	cachedTemplates = TEMPLATES.filter((t) => {
+		if (typeof t.isEnabled === "function") return t.isEnabled();
+		return true;
+	});
+
+	return cachedTemplates;
+}
+
+/**
+ * 이름으로 템플릿을 찾습니다.
+ */
+export function findTemplate(name: string): TemplateDefinition | undefined {
+	return getTemplates().find((t) => t.name === name);
+}
+
+/**
+ * 템플릿 파일이 위치한 절대 경로를 반환합니다.
+ */
+export function getTemplateDir(templateName: string): string {
+	const currentFilename = fileURLToPath(import.meta.url);
+	const cliRoot = path.resolve(path.dirname(currentFilename), "..");
+	return path.resolve(cliRoot, "templates", templateName);
+}
+
+/**
+ * 템플릿이 실제로 디스크에 존재하는지 확인합니다.
+ */
+export function templateExists(templateName: string): boolean {
+	return fs.existsSync(getTemplateDir(templateName));
+}
+
+/** 테스트용: 캐시를 초기화합니다. */
+export function _resetTemplateCache(): void {
+	cachedTemplates = null;
+}

--- a/src/steps/prompt.ts
+++ b/src/steps/prompt.ts
@@ -1,26 +1,18 @@
 import { cancel, intro, isCancel, select, text } from "@clack/prompts";
 import fs from "node:fs";
 import path from "node:path";
-
-/**
- * @description
- * 사용자가 선택 가능한 디자인 시스템 종류입니다.
- *
- * - design-system: @bigtablet/design-system (SCSS 기반 사내 컴포넌트)
- * - shadcn: shadcn/ui (Tailwind CSS + Radix UI)
- */
-export type DesignSystemChoice = "design-system" | "shadcn";
+import { getTemplates } from "src/registry";
 
 /**
  * @description
  * CLI 프롬프트에서 수집한 프로젝트 설정을 담는 타입입니다.
  *
  * @property projectName - 생성할 프로젝트 디렉토리 이름
- * @property designSystem - 선택된 디자인 시스템
+ * @property templateName - 선택된 템플릿 이름 (registry의 TemplateDefinition.name)
  */
 export type ProjectConfig = {
 	projectName: string;
-	designSystem: DesignSystemChoice;
+	templateName: string;
 };
 
 /**
@@ -29,7 +21,7 @@ export type ProjectConfig = {
  *
  * 수집 항목:
  * 1. 프로젝트 이름 (process.argv[2]로 사전 입력 가능)
- * 2. 디자인 시스템 선택
+ * 2. 템플릿 선택 (registry에 등록된 항목을 동적으로 표시)
  *
  * Ctrl+C 또는 취소 선택 시 프로세스를 종료합니다.
  *
@@ -56,29 +48,23 @@ export const runPrompts = async (initialProjectName?: string): Promise<ProjectCo
 		process.exit(0);
 	}
 
-	const designSystem = await select({
-		message: "디자인 시스템을 선택하세요:",
-		options: [
-			{
-				value: "design-system",
-				label: "@bigtablet/design-system",
-				hint: "Bigtablet 사내 컴포넌트 (SCSS)",
-			},
-			{
-				value: "shadcn",
-				label: "shadcn/ui",
-				hint: "Tailwind CSS v4 + Radix UI",
-			},
-		],
+	const templates = getTemplates();
+	const templateName = await select({
+		message: "템플릿을 선택하세요:",
+		options: templates.map((t) => ({
+			value: t.name,
+			label: t.label,
+			hint: t.hint,
+		})),
 	});
 
-	if (isCancel(designSystem)) {
+	if (isCancel(templateName)) {
 		cancel("작업이 취소됐습니다.");
 		process.exit(0);
 	}
 
 	return {
 		projectName: projectName as string,
-		designSystem: designSystem as DesignSystemChoice,
+		templateName: templateName as string,
 	};
 };

--- a/src/steps/scaffold.ts
+++ b/src/steps/scaffold.ts
@@ -1,8 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-import type { DesignSystemChoice } from "src/steps/prompt";
+import { findTemplate, getTemplateDir, templateExists } from "src/registry";
 import type { PackageManagerInfo } from "src/utils/package-manager";
 
 const GITIGNORE_CONTENT = [
@@ -24,76 +22,59 @@ const GITIGNORE_CONTENT = [
 
 /**
  * @description
- * CLI 패키지의 루트 디렉토리 절대 경로를 반환합니다.
- * tsup 빌드 후 bin/ 에 위치한 파일 기준으로 두 단계 상위가 루트입니다.
- */
-const getCliRootDirectory = (): string => {
-	const currentFilename = fileURLToPath(import.meta.url);
-	return path.resolve(path.dirname(currentFilename), "..");
-};
-
-/**
- * @description
- * 선택한 디자인 시스템에 해당하는 템플릿 디렉토리 경로를 반환합니다.
- *
- * templates/design-system/ 또는 templates/shadcn/ 중 하나를 반환합니다.
- *
- * @param cliRootDirectory - CLI 패키지 루트 경로
- * @param designSystemChoice - 사용자가 선택한 디자인 시스템
- * @returns 템플릿 디렉토리 절대 경로
- */
-const getTemplateDirectory = (
-	cliRootDirectory: string,
-	designSystemChoice: DesignSystemChoice,
-): string => {
-	return path.resolve(
-		cliRootDirectory,
-		"templates",
-		designSystemChoice,
-	);
-};
-
-/**
- * @description
  * 프로젝트를 스캐폴딩합니다.
  *
- * 각 디자인 시스템별 독립 템플릿(templates/{choice}/)을 그대로 복사합니다.
- *
  * 실행 순서:
- * 1. 선택된 디자인 시스템의 템플릿 전체 복사
+ * 1. 선택된 템플릿의 파일 전체 복사 (templates/{templateName}/)
  * 2. .gitignore 생성
  * 3. .env.example 생성
  * 4. package.json 프로젝트명 치환 (__PROJECT_NAME__ → projectName)
  * 5. packageManager 필드 기록
+ * 6. 템플릿의 afterScaffold() 실행 (템플릿별 후처리)
  *
  * @param projectName - 생성할 프로젝트 이름
- * @param designSystemChoice - 선택된 디자인 시스템
+ * @param templateName - 선택된 템플릿 이름 (registry 기준)
  * @param packageManagerInfo - 감지된 패키지 매니저 정보
  * @returns 생성된 프로젝트 디렉토리의 절대 경로
  */
-export const scaffoldProject = (
+export const scaffoldProject = async (
 	projectName: string,
-	designSystemChoice: DesignSystemChoice,
+	templateName: string,
 	packageManagerInfo: PackageManagerInfo,
-): string => {
-	const targetDirectory = path.resolve(process.cwd(), projectName);
-	const cliRootDirectory = getCliRootDirectory();
-	const templateDirectory = getTemplateDirectory(cliRootDirectory, designSystemChoice);
-
-	fs.cpSync(templateDirectory, targetDirectory, { recursive: true });
-
-	fs.writeFileSync(path.join(targetDirectory, ".gitignore"), GITIGNORE_CONTENT);
-	fs.writeFileSync(path.join(targetDirectory, ".env.example"), "NEXT_PUBLIC_SERVER_URL=\n");
-
-	const packageJsonPath = path.join(targetDirectory, "package.json");
-	const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
-	fs.writeFileSync(packageJsonPath, packageJsonContent.replace("__PROJECT_NAME__", projectName));
-
-	if (packageManagerInfo.version) {
-		const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-		packageJson.packageManager = `${packageManagerInfo.name}@${packageManagerInfo.version}`;
-		fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, "\t") + "\n");
+): Promise<string> => {
+	if (!templateExists(templateName)) {
+		throw new Error(`템플릿 "${templateName}"을(를) 찾을 수 없습니다.`);
 	}
 
-	return targetDirectory;
+	const targetDirectory = path.resolve(process.cwd(), projectName);
+
+	try {
+		const templateDirectory = getTemplateDir(templateName);
+
+		fs.cpSync(templateDirectory, targetDirectory, { recursive: true });
+
+		fs.writeFileSync(path.join(targetDirectory, ".gitignore"), GITIGNORE_CONTENT);
+		fs.writeFileSync(path.join(targetDirectory, ".env.example"), "NEXT_PUBLIC_SERVER_URL=\n");
+
+		const packageJsonPath = path.join(targetDirectory, "package.json");
+		const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
+		fs.writeFileSync(packageJsonPath, packageJsonContent.replace("__PROJECT_NAME__", projectName));
+
+		if (packageManagerInfo.version) {
+			const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+			packageJson.packageManager = `${packageManagerInfo.name}@${packageManagerInfo.version}`;
+			fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, "\t") + "\n");
+		}
+
+		// 템플릿별 후처리 실행 (각 템플릿이 직접 정의)
+		const template = findTemplate(templateName);
+		if (template?.afterScaffold) {
+			await template.afterScaffold(targetDirectory);
+		}
+
+		return targetDirectory;
+	} catch (error) {
+		fs.rmSync(targetDirectory, { recursive: true, force: true });
+		throw error;
+	}
 };

--- a/src/steps/scaffold.ts
+++ b/src/steps/scaffold.ts
@@ -57,14 +57,15 @@ export const scaffoldProject = async (
 		fs.writeFileSync(path.join(targetDirectory, ".env.example"), "NEXT_PUBLIC_SERVER_URL=\n");
 
 		const packageJsonPath = path.join(targetDirectory, "package.json");
-		const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
-		fs.writeFileSync(packageJsonPath, packageJsonContent.replace("__PROJECT_NAME__", projectName));
+		let packageJsonContent = fs.readFileSync(packageJsonPath, "utf8").replace("__PROJECT_NAME__", projectName);
 
 		if (packageManagerInfo.version) {
-			const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+			const packageJson = JSON.parse(packageJsonContent);
 			packageJson.packageManager = `${packageManagerInfo.name}@${packageManagerInfo.version}`;
-			fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, "\t") + "\n");
+			packageJsonContent = JSON.stringify(packageJson, null, "\t") + "\n";
 		}
+
+		fs.writeFileSync(packageJsonPath, packageJsonContent);
 
 		// 템플릿별 후처리 실행 (각 템플릿이 직접 정의)
 		const template = findTemplate(templateName);


### PR DESCRIPTION
## 제목
refactor/template-registry

## 작업한 내용
- [x] 하드코딩된 디자인 시스템 선택지를 src/registry.ts 레지스트리 패턴으로 전환
- [x] 스캐폴딩 전 templateExists() 검증 및 실패 시 디렉토리 자동 정리 추가
- [x] Issue 템플릿을 Task / Feature / Bug / Security 4종으로 세분화
- [x] bin 빌드 산출물 갱신

## 전달할 추가 이슈
- 없음