### PR TITLE
deploy/pnpm-action-setup-5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           git reset --hard origin/main
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## 제목
deploy/pnpm-action-setup-5

## 작업한 내용
- [x] pnpm/action-setup v4 → v5 업그레이드 (ci.yml, deploy.yml)

## 전달할 추가 이슈
- v6은 pnpm 11을 기본 설치하면서 v10 lockfile 호환 문제 발생하여 v5로 적용
- v5 변경사항: Node.js 24 런타임 지원 (프로젝트 환경과 일치)