### PR TITLE
docs/pr-review-workflow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,108 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# CodeRabbit 설정 — bigtablet-frontend-template (Next.js 템플릿 스캐폴더 CLI).
+# 이 레포는 모노레포가 아니다: 루트(src/, bin/)는 CLI, 실제 앱 코드는
+# templates/{shadcn,design-system}/src/ 에 FSD 로 들어있다.
+# 규칙 출처: templates/*/CLAUDE.md, templates/*/.claude/docs/{code-style,react-patterns,design-system,git-workflow}.md
+# 리뷰는 한국어, 머지 차단은 CI 게이트가 담당(코드래빗은 권고만).
+
+language: "ko-KR"
+
+tone_instructions: >-
+  한국어로 리뷰하라. 사실·근거 위주로 간결하게. 불필요한 인사·칭찬·동의 요청 같은
+  트래킹성 문구는 쓰지 마라. 코드/커밋 메시지/PR 제목 인용은 원문 그대로 둔다.
+
+early_access: false
+
+reviews:
+  profile: "chill" # nitpick 폭주 방지. 더 깐깐히 원하면 "assertive".
+  request_changes_workflow: false # 코드래빗이 머지를 막지 않음 — CI/사람이 게이트.
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  changed_files_summary: true
+  sequence_diagrams: false
+
+  auto_review:
+    enabled: true
+    drafts: false # Draft PR 은 리뷰 안 함.
+    base_branches:
+      - "develop" # 일반 PR base
+      - "main" # 릴리스 PR base
+
+  # 리뷰 대상에서 제외할 경로(생성물·락파일·빌드 산출물·벤더 스킬 문서).
+  path_filters:
+    - "!**/pnpm-lock.yaml"
+    - "!bin/**" # tsup 빌드 산출물 (src/index.ts 에서 생성)
+    - "!**/dist/**"
+    - "!**/.next/**"
+    - "!**/coverage/**"
+    - "!**/node_modules/**"
+    - "!**/*.min.css"
+    - "!**/*.snap"
+    - "!**/.agents/**" # 벤더링된 스킬 규칙 파일
+
+  path_instructions:
+    - path: "templates/**/*.{ts,tsx}"
+      instructions: >-
+        FSD 레이어 의존 규칙을 강제하라. import 방향은 app → widgets → features →
+        entities → shared 단방향이다. 역방향 import(예: shared 가 entities 이상을
+        import)와 같은 레이어 간 peer-slice import(예: entities/A → entities/B)는 지적하라.
+        모든 컴포넌트·함수에 JSDoc(@description) 이 있는지 확인하고 없으면 지적하라.
+        정적 JSX·데이터는 모듈 스코프로 hoist 되어 매 렌더 재생성되지 않게 하라.
+        2곳 이상 반복되는 로직은 util/hook 추출을 제안하라(중복 금지, 단일 출처 원칙).
+        인증·결제·데이터 변경 같은 critical API 호출은 반드시 await 하라 — fire-and-forget
+        (await 없는 비동기 호출)은 지적하라.
+        데이터 패칭/뮤테이션은 React Query 패턴을 따르고, QueryClient 는 createDefaultQueryClient
+        를, 전역 에러/성공 토스트는 mutation-cache(meta.errorMessage / successMessage)를 쓴다.
+        재시도는 React Query 레이어(queries.retry)가 단일 소스다 — axios transport 에서 재시도
+        로직을 추가하지 마라.
+        보안: 입력은 서버에서 검증하고, 출력은 인코딩해 XSS 를 막고, 민감정보를 클라이언트에
+        노출하지 마라.
+        React: 서버/클라이언트 컴포넌트 경계를 적절히 두고("use client" 남용 금지),
+        로딩 상태는 skeleton UI 패턴을 따르라.
+        컴포넌트 파일명은 index.tsx 여야 한다.
+    - path: "templates/design-system/**/*.module.scss"
+      instructions: >-
+        하드코딩된 값(색상·간격·radius·폰트·shadow 등)은 금지다. 반드시 디자인 시스템 토큰
+        (@bigtablet/design-system/scss/token)을 써야 한다. 하드코딩 리터럴(#hex, px 매직넘버 등)을
+        발견하면 대응 토큰 사용을 제안하라.
+        토큰 이름은 v3 기준이다: 색상은 semantic 토큰($color_bg_solid, $color_text_body,
+        $color_border_default, $color_status_* 등), 간격은 숫자 스케일($spacing_8/12/16/20…),
+        shadow 는 $elevation_level1~5, 타이포는 mixin($include body_small 등)을 쓴다.
+        스타일 파일명은 style.module.scss 여야 한다.
+    - path: "templates/shadcn/**/*.{ts,tsx}"
+      instructions: >-
+        스타일링은 Tailwind CSS v4 + cn() 유틸(src/shared/libs/ui/cn.ts)을 쓴다. shadcn 컴포넌트는
+        src/shared/ui 에 두고(npx shadcn add), variant 는 class-variance-authority(cva)로 만든다.
+        토스트는 sonner 의 toast() 를 직접 호출한다(design-system 의 useToast 미사용).
+    - path: "src/**/*.ts"
+      instructions: >-
+        루트 src/ 는 스캐폴더 CLI 소스다 — FSD/React 규칙은 적용하지 마라. 템플릿 복사·치환
+        로직의 정확성, 파일시스템 에러 처리, 사용자 입력 검증, 크로스 플랫폼(경로 구분자 등)
+        안전성 위주로 리뷰하라.
+    - path: "templates/**/package.json"
+      instructions: >-
+        템플릿 매니페스트다. next/react/react-dom/@biomejs/biome 는 정확한 버전으로 핀(^ 없음)
+        되어 있어야 재현 가능하다. 핵심 의존성(Next 16 / React 19 / TypeScript 6 / @bigtablet/design-system v3)
+        의 버전 일관성을 확인하고, 메이저가 뒤처진 의존성은 지적하라.
+
+  tools:
+    biome:
+      enabled: true # 템플릿 린터/포매터(biome 2.5.1)와 정합.
+    gitleaks:
+      enabled: true # 시크릿 유출 스캔.
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/CLAUDE.md"
+      - "**/AGENTS.md"
+      - "**/.claude/docs/**"
+      - "**/architecture.md"
+      - "**/README.md"

--- a/templates/design-system/.claude/docs/git-workflow.md
+++ b/templates/design-system/.claude/docs/git-workflow.md
@@ -65,6 +65,62 @@ label/domain
 - Pull Request를 열었다면 반드시 팀원에게 Review를 요청
 - 요청을 받은 팀원은 Review 후 Approve 혹은 Comment 등으로 코드 리뷰를 성실히 수행
 - Approve가 내려지기 전에 해당 Pull Request는 병합하지 않음
+- 리뷰 코멘트에는 **각각 답글로 응대**하고, 반영이 끝난 스레드는 **resolve** 처리
+
+### 리뷰어 멘션 / 요청
+
+```bash
+# 리뷰어 지정
+gh pr edit <PR번호> --add-reviewer 깃헙아이디1,깃헙아이디2
+
+# 코멘트로 멘션 (일반 코멘트)
+gh pr comment <PR번호> --body "@깃헙아이디 리뷰 부탁드립니다 🙏"
+```
+
+### 리뷰 코멘트 답글
+
+인라인 리뷰 코멘트 답글은 `gh api`로 단다 (gh CLI 전용 명령 없음). `{owner}/{repo}`는 실제 값으로 치환.
+
+```bash
+# 1) 리뷰 코멘트 목록 + id 확인
+gh api repos/{owner}/{repo}/pulls/<PR번호>/comments \
+  --jq '.[] | {id, path, line, body: .body[0:60]}'
+
+# 2) 특정 코멘트에 답글 (해당 스레드로 연결)
+gh api repos/{owner}/{repo}/pulls/<PR번호>/comments/<코멘트id>/replies \
+  -f body="반영했습니다. 감사합니다 🙏"
+
+# PR 전체에 대한 일반 코멘트는 gh pr comment 사용
+gh pr comment <PR번호> --body "리뷰 반영 완료했습니다"
+```
+
+### 리뷰 스레드 resolve
+
+스레드 resolve는 GraphQL `resolveReviewThread` 뮤테이션을 사용한다 (REST 미지원).
+
+```bash
+# 1) 미해결 스레드 id 조회
+gh api graphql -f query='
+  query($owner:String!,$repo:String!,$num:Int!){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$num){
+        reviewThreads(first:100){
+          nodes{ id isResolved comments(first:1){ nodes{ path body } } }
+        }
+      }
+    }
+  }' -f owner=<owner> -f repo=<repo> -F num=<PR번호> \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+        | select(.isResolved|not)
+        | {id, path: .comments.nodes[0].path}'
+
+# 2) 스레드 resolve (위에서 얻은 node id 사용)
+gh api graphql -f query='
+  mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ isResolved } } }' \
+  -f id=<스레드id>
+```
+
+> **답글 → (필요 시 수정·푸시) → resolve** 순서를 지킨다. 리뷰어가 무엇이 반영됐는지 추적할 수 있도록, 답글 없이 임의로 resolve 하지 않는다.
 
 ## Claude Workflow
 
@@ -138,7 +194,15 @@ EOF
 )"
 ```
 
-### 6. Release PR 생성 (develop → main 배포 시)
+### 6. Review 응대
+
+리뷰 코멘트가 달리면 각 코멘트에 답글을 달고, 반영이 끝난 스레드는 resolve 한다. (명령은 위 [Review](#review) 섹션 참고)
+
+- **수정이 필요한 코멘트**: 코드 수정 → 커밋·푸시 → 해당 코멘트에 답글(`반영했습니다`) → 스레드 resolve
+- **반영하지 않을 코멘트**: 이유를 답글로 남기고 리뷰어 판단을 기다린다 (임의 resolve 금지)
+- **본인 PR은 본인이 머지하지 않는다** — Approve 후 브랜치 생성자가 머지
+
+### 7. Release PR 생성 (develop → main 배포 시)
 
 - **Base branch**: `main`
 - **PR title**: `release/v버전` 형식
@@ -186,3 +250,5 @@ EOF
 - Issue와 PR 본문은 한글로 작성
 - **커밋 메시지는 반드시 영문 소문자 사용**
 - Approve 없이 병합 금지
+- 리뷰 코멘트는 답글로 응대 후 반영 완료 스레드만 resolve (임의 resolve 금지)
+- 본인 PR은 본인이 머지하지 않음 (브랜치 생성자가 Approve 후 머지)

--- a/templates/design-system/CLAUDE.md
+++ b/templates/design-system/CLAUDE.md
@@ -147,6 +147,7 @@ BFF(Backend for Frontend) 패턴을 사용할 경우:
   3. 구현 + 커밋 (영문)
   4. PR 생성 (title = 브랜치명, base = `develop`)
   5. PR에 `Closes #이슈번호` 추가
+  6. Review 응대 — 코멘트마다 답글 + 반영 완료 스레드 resolve
 - **PR/Issue 본문 템플릿** (자의적 변경 금지):
   ```
   ## 제목
@@ -159,4 +160,6 @@ BFF(Backend for Frontend) 패턴을 사용할 경우:
   - 없음
   ```
 - **PR 제목 = 브랜치명** (설명문 아님, 예: `fix/detail-page-pagination`)
+- **Review 응대**: 리뷰 코멘트에 답글(`gh api repos/{owner}/{repo}/pulls/<n>/comments/<id>/replies`) 후 반영 완료 스레드 resolve(GraphQL `resolveReviewThread`); 리뷰어 멘션 `gh pr edit <n> --add-reviewer <id>`. 자세히는 [git-workflow.md](.claude/docs/git-workflow.md)
+- **본인 PR 본인 머지 금지** (Approve 후 브랜치 생성자가 머지)
 - **Release PR**: `develop → main` 배포 시 title = `release/v버전`, base = `main`

--- a/templates/shadcn/.claude/docs/git-workflow.md
+++ b/templates/shadcn/.claude/docs/git-workflow.md
@@ -65,6 +65,62 @@ label/domain
 - Pull Request를 열었다면 반드시 팀원에게 Review를 요청
 - 요청을 받은 팀원은 Review 후 Approve 혹은 Comment 등으로 코드 리뷰를 성실히 수행
 - Approve가 내려지기 전에 해당 Pull Request는 병합하지 않음
+- 리뷰 코멘트에는 **각각 답글로 응대**하고, 반영이 끝난 스레드는 **resolve** 처리
+
+### 리뷰어 멘션 / 요청
+
+```bash
+# 리뷰어 지정
+gh pr edit <PR번호> --add-reviewer 깃헙아이디1,깃헙아이디2
+
+# 코멘트로 멘션 (일반 코멘트)
+gh pr comment <PR번호> --body "@깃헙아이디 리뷰 부탁드립니다 🙏"
+```
+
+### 리뷰 코멘트 답글
+
+인라인 리뷰 코멘트 답글은 `gh api`로 단다 (gh CLI 전용 명령 없음). `{owner}/{repo}`는 실제 값으로 치환.
+
+```bash
+# 1) 리뷰 코멘트 목록 + id 확인
+gh api repos/{owner}/{repo}/pulls/<PR번호>/comments \
+  --jq '.[] | {id, path, line, body: .body[0:60]}'
+
+# 2) 특정 코멘트에 답글 (해당 스레드로 연결)
+gh api repos/{owner}/{repo}/pulls/<PR번호>/comments/<코멘트id>/replies \
+  -f body="반영했습니다. 감사합니다 🙏"
+
+# PR 전체에 대한 일반 코멘트는 gh pr comment 사용
+gh pr comment <PR번호> --body "리뷰 반영 완료했습니다"
+```
+
+### 리뷰 스레드 resolve
+
+스레드 resolve는 GraphQL `resolveReviewThread` 뮤테이션을 사용한다 (REST 미지원).
+
+```bash
+# 1) 미해결 스레드 id 조회
+gh api graphql -f query='
+  query($owner:String!,$repo:String!,$num:Int!){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$num){
+        reviewThreads(first:100){
+          nodes{ id isResolved comments(first:1){ nodes{ path body } } }
+        }
+      }
+    }
+  }' -f owner=<owner> -f repo=<repo> -F num=<PR번호> \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+        | select(.isResolved|not)
+        | {id, path: .comments.nodes[0].path}'
+
+# 2) 스레드 resolve (위에서 얻은 node id 사용)
+gh api graphql -f query='
+  mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ isResolved } } }' \
+  -f id=<스레드id>
+```
+
+> **답글 → (필요 시 수정·푸시) → resolve** 순서를 지킨다. 리뷰어가 무엇이 반영됐는지 추적할 수 있도록, 답글 없이 임의로 resolve 하지 않는다.
 
 ## Claude Workflow
 
@@ -138,7 +194,15 @@ EOF
 )"
 ```
 
-### 6. Release PR 생성 (develop → main 배포 시)
+### 6. Review 응대
+
+리뷰 코멘트가 달리면 각 코멘트에 답글을 달고, 반영이 끝난 스레드는 resolve 한다. (명령은 위 [Review](#review) 섹션 참고)
+
+- **수정이 필요한 코멘트**: 코드 수정 → 커밋·푸시 → 해당 코멘트에 답글(`반영했습니다`) → 스레드 resolve
+- **반영하지 않을 코멘트**: 이유를 답글로 남기고 리뷰어 판단을 기다린다 (임의 resolve 금지)
+- **본인 PR은 본인이 머지하지 않는다** — Approve 후 브랜치 생성자가 머지
+
+### 7. Release PR 생성 (develop → main 배포 시)
 
 - **Base branch**: `main`
 - **PR title**: `release/v버전` 형식
@@ -186,3 +250,5 @@ EOF
 - Issue와 PR 본문은 한글로 작성
 - **커밋 메시지는 반드시 영문 소문자 사용**
 - Approve 없이 병합 금지
+- 리뷰 코멘트는 답글로 응대 후 반영 완료 스레드만 resolve (임의 resolve 금지)
+- 본인 PR은 본인이 머지하지 않음 (브랜치 생성자가 Approve 후 머지)

--- a/templates/shadcn/CLAUDE.md
+++ b/templates/shadcn/CLAUDE.md
@@ -145,6 +145,7 @@ BFF(Backend for Frontend) 패턴을 사용할 경우:
   3. 구현 + 커밋 (영문)
   4. PR 생성 (title = 브랜치명, base = `develop`)
   5. PR에 `Closes #이슈번호` 추가
+  6. Review 응대 — 코멘트마다 답글 + 반영 완료 스레드 resolve
 - **PR/Issue 본문 템플릿** (자의적 변경 금지):
   ```
   ## 제목
@@ -157,4 +158,6 @@ BFF(Backend for Frontend) 패턴을 사용할 경우:
   - 없음
   ```
 - **PR 제목 = 브랜치명** (설명문 아님, 예: `fix/detail-page-pagination`)
+- **Review 응대**: 리뷰 코멘트에 답글(`gh api repos/{owner}/{repo}/pulls/<n>/comments/<id>/replies`) 후 반영 완료 스레드 resolve(GraphQL `resolveReviewThread`); 리뷰어 멘션 `gh pr edit <n> --add-reviewer <id>`. 자세히는 [git-workflow.md](.claude/docs/git-workflow.md)
+- **본인 PR 본인 머지 금지** (Approve 후 브랜치 생성자가 머지)
 - **Release PR**: `develop → main` 배포 시 title = `release/v버전`, base = `main`


### PR DESCRIPTION
## 제목
docs/pr-review-workflow

## 작업한 내용
- [x] git-workflow.md: `## Review` 섹션에 리뷰어 멘션/요청, 인라인 코멘트 답글, 스레드 resolve용 `gh`/`gh api`/GraphQL 명령 추가
- [x] git-workflow.md: Claude Workflow에 `### 6. Review 응대` 단계 추가 (답글→수정·푸시→resolve, 임의 resolve 금지, 본인 PR 본인 머지 금지), Release PR 7번으로 재번호
- [x] CLAUDE.md(Git Summary): Review 응대 단계 + 멘션/답글/resolve 명령 요약 + 본인 머지 금지 추가
- [x] 두 템플릿(shadcn, design-system) 동일 적용

## 전달할 추가 이슈
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)