### PR TITLE
config/dependabot-monthly-develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      # dependabot은 cron("첫째주 월요일")을 지원하지 않음 — monthly = 매월 1일 실행.
+      interval: "monthly"
       time: "08:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
@@ -20,12 +21,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "08:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
-    target-branch: "main"
+    target-branch: "develop"
     commit-message:
       prefix: "deploy"
       include: "scope"


### PR DESCRIPTION
## 제목
config/dependabot-monthly-develop

## 작업한 내용
- [x] dependabot npm 스케줄 daily → **monthly**
- [x] dependabot github-actions 스케줄 weekly(monday) → **monthly**, target-branch `main` → **`develop`**
- [x] 이제 두 ecosystem 모두 develop으로 PR

## 전달할 추가 이슈
- ⚠️ **dependabot은 cron/"첫째주 월요일"을 지원하지 않음**. 스케줄 옵션은 daily/weekly/monthly뿐 (monthly = 매월 1일 실행). 굳이 월요일 cadence가 필요하면 weekly+monday(매주 월), 정확히 첫째주 월요일이면 GitHub Actions cron(`0 8 1-7 * 1`)으로 `dependabot update` 트리거하는 별도 워크플로우가 필요.
- ⚠️ **dependabot은 config를 기본 브랜치(main)에서 읽음**. 이 변경은 develop → main 릴리스로 반영된 뒤에야 적용됨. 즉시 적용하려면 main 타겟 PR 필요 (말해주면 진행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependabot 업데이트 주기가 조정되어, npm은 월 1회로 변경되었습니다.
  * GitHub Actions 업데이트도 월 1회로 변경되었고, 대상 브랜치가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->