### PR TITLE
config/dependabot-monthly-main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      # dependabot은 cron("첫째주 월요일")을 지원하지 않음 — monthly = 매월 1일 실행.
+      interval: "monthly"
       time: "08:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
@@ -20,12 +21,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "08:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
-    target-branch: "main"
+    target-branch: "develop"
     commit-message:
       prefix: "deploy"
       include: "scope"


### PR DESCRIPTION
## 제목
config/dependabot-monthly-main

## 작업한 내용
- [x] dependabot 스케줄 monthly + 두 ecosystem(npm·github-actions) 모두 develop 타겟 (PR #104와 동일 변경)
- [x] **즉시 적용용 main 타겟 PR** — dependabot은 기본 브랜치(main)에서 config를 읽으므로, 이 PR이 머지되면 바로 새 스케줄 적용

## 전달할 추가 이슈
- develop 타겟 동일 PR(#104)도 열려 있음 — 둘 다 머지하면 main/develop 양쪽 config 동기화 (다음 릴리스 때 develop가 main을 덮어쓰지 않도록)
- monthly = 매월 1일 실행 (dependabot은 "첫째주 월요일" 미지원)

🤖 Generated with [Claude Code](https://claude.com/claude-code)