### PR TITLE
docs/readme-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ node bin/create-bigtablet-frontend.js my-test-app
 bigtablet-frontend-template/
 ├── src/                        # CLI TypeScript 소스
 │   ├── index.ts                # 진입점
+│   ├── registry.ts             # 템플릿 레지스트리 (shadcn / design-system)
 │   ├── steps/
 │   │   ├── prompt.ts           # @clack/prompts 대화형 입력
 │   │   ├── scaffold.ts         # 템플릿 복사 + 프로젝트 설정
@@ -130,7 +131,7 @@ commitlint + Husky를 통해 커밋 메시지 형식을 강제합니다.
 <type>: <subject>
 ```
 
-허용 타입: `feat`, `fix`, `merge`, `deploy`, `docs`, `delete`, `note`, `style`, `config`, `etc`, `tada`
+허용 타입: `feat`, `fix`, `bug`, `merge`, `deploy`, `docs`, `delete`, `note`, `style`, `config`, `chore`, `test`, `etc`, `tada`
 
 ---
 


### PR DESCRIPTION
## 제목
docs/readme-fixes

## 작업한 내용
- [x] README 파일 구조 트리에 누락된 `src/registry.ts` 추가
- [x] 커밋 타입 목록을 commitlint.config.mjs와 일치 (`bug`, `chore`, `test` 추가)

## 전달할 추가 이슈
- 나머지 README(사용법/CLI 명령/디자인시스템 설명/architecture 링크)는 정확함. 버전 숫자를 박지 않아 의존성 bump에 늙지 않는 구조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)