### PR TITLE
config/release-oidc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,9 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
-  id-token: write
+  id-token: write # npm OIDC (trusted publishing) + GitHub release
 
 jobs:
   release:
@@ -41,9 +42,11 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # npm OIDC(trusted publishing)는 npm CLI >= 11.5.1 필요. node 24 기본 npm 보강.
+      - name: Ensure npm supports OIDC
+        run: npm install -g npm@latest
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## 제목
config/release-oidc

## 작업한 내용
- [x] deploy.yml: `issues: write` 권한 추가 (semantic-release github 플러그인이 성공 시 PR 코멘트 / 실패 시 이슈 생성 — 기존 403 원인)
- [x] Release 스텝에서 `NPM_TOKEN`/`NODE_AUTH_TOKEN` 제거 → **순수 OIDC** (semantic-release v25 + @semantic-release/npm v13이 GitHub OIDC 토큰을 npm 단기 자격증명으로 교환)
- [x] `npm install -g npm@latest` 스텝 추가 (OIDC는 npm >= 11.5.1 필요)

## ⚠️ 머지 전 필수 (npm 쪽 수동 설정 — UI)
> **trusted publisher 설정 전에 머지하면 릴리스 또 실패함** (main push → deploy.yml 트리거). 순서 지켜야 함.

1. npmjs.com → `@bigtablet/create-frontend` 패키지 → **Settings → Trusted Publishing → GitHub Actions** 추가
   - Organization/owner: `Bigtablet`
   - Repository: `bigtablet-frontend-template`
   - Workflow filename: `deploy.yml`
   - Environment: (비움 — 워크플로 environment 미사용)
2. (선택) 설정 후 무효한 `NPM_TOKEN` secret 삭제 — 더 이상 안 씀

## 전달할 추가 이슈
- 직전 v1.8.0 릴리스는 코드만 main 머지됨(npm publish 실패) → 버전 1.7.2 그대로, 태그/CHANGELOG 없음. 이 PR 머지(또는 실패한 deploy 워크플로 재실행)하면 semantic-release가 1.8.0 다시 시도 → 정상 publish.
- 같은 변경을 develop에도 동기화 필요(다음 릴리스가 main workflow 안 덮게).

🤖 Generated with [Claude Code](https://claude.com/claude-code)