### PR TITLE
config/pkg-repository-field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "version": "1.8.0",
   "type": "module",
   "description": "Bigtablet Next.js frontend template",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Bigtablet/bigtablet-frontend-template.git"
+  },
   "bin": {
     "create-bigtablet-frontend": "bin/create-bigtablet-frontend.js"
   },


### PR DESCRIPTION
## 제목
config/pkg-repository-field

## 작업한 내용
- [x] package.json에 `repository` 필드 추가 (npm provenance 필수)

## 배경
OIDC trusted publishing은 npm **provenance**를 자동 활성화함. provenance는 `package.json.repository.url`이 빌드한 GitHub repo와 일치하는지 검증하는데, 필드가 없어 직전 publish가 **E422**(`sigstore provenance: repository.url is """)로 실패함. OIDC·인증·서명은 모두 정상 통과했고 이 필드만 누락이었음.

## ⚠️ 머지 시 동작
- 머지 → main push → deploy.yml(OIDC) 재실행
- 1.8.0은 git 태그만 있고 npm 미publish 상태 → 태그 1.8.0 존재로 인해 다음 릴리스는 **1.8.1**로 진행되어 npm에 publish됨 (1.8.0 내용 전부 포함, provenance 정상)

## 전달할 추가 이슈
- 같은 `repository` 필드 + OIDC deploy.yml(#108)을 develop에도 동기화 필요 (다음 릴리스부터 일관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)